### PR TITLE
KI-701 update_user and custom claims

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,4 @@
 
 source "https://rubygems.org"
 
-ruby "3.2.2"
-
 gemspec

--- a/firebase-admin-sdk.gemspec
+++ b/firebase-admin-sdk.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "fakefs"
   spec.add_development_dependency "climate_control"
   spec.add_development_dependency "standard"
-  spec.add_development_dependency "activesupport", "~> 7.0.8"
+  spec.add_development_dependency "activesupport"
 end

--- a/lib/firebase/admin/auth/client.rb
+++ b/lib/firebase/admin/auth/client.rb
@@ -35,11 +35,12 @@ module Firebase
         # @param [String, nil] photo_url The user’s photo URL.
         # @param [String, nil] password The user’s raw, unhashed password.
         # @param [Boolean, nil] disabled A boolean indicating whether or not the user account is disabled.
+        # @param [Hash, nil] custom_claims "Custom attributes" to store on the user, which will appear in their auth token.
         #
         # @raise [CreateUserError] if a user cannot be created.
         #
         # @return [UserRecord]
-        def create_user(uid: nil, display_name: nil, email: nil, email_verified: nil, phone_number: nil, photo_url: nil, password: nil, disabled: nil)
+        def create_user(uid: nil, display_name: nil, email: nil, email_verified: nil, phone_number: nil, photo_url: nil, password: nil, disabled: nil, custom_claims: nil)
           @user_manager.create_user(
             uid: uid,
             display_name: display_name,
@@ -48,7 +49,8 @@ module Firebase
             phone_number: phone_number,
             photo_url: photo_url,
             password: password,
-            disabled: disabled
+            disabled: disabled,
+            custom_claims: custom_claims,
           )
         end
 
@@ -97,11 +99,12 @@ module Firebase
         # @param [String, nil] photo_url The user’s photo URL.
         # @param [String, nil] password The user’s raw, unhashed password.
         # @param [Boolean, nil] disabled A boolean indicating whether or not the user account is disabled.
+        # @param [Hash, nil] custom_claims "Custom attributes" to store on the user, which will appear in their auth token. Set to an empty hash to clear.
         #
         # @raise [UpdateUserError] if a user cannot be updated.
         #
         # @return [UserRecord]
-        def update_user(uid: nil, display_name: nil, email: nil, email_verified: nil, phone_number: nil, photo_url: nil, password: nil, disabled: nil)
+        def update_user(uid: nil, display_name: nil, email: nil, email_verified: nil, phone_number: nil, photo_url: nil, password: nil, disabled: nil, custom_claims: nil)
           @user_manager.update_user(
             uid: uid,
             display_name: display_name,
@@ -110,7 +113,8 @@ module Firebase
             phone_number: phone_number,
             photo_url: photo_url,
             password: password,
-            disabled: disabled
+            disabled: disabled,
+            custom_claims: custom_claims,
           )
         end
 

--- a/lib/firebase/admin/auth/client.rb
+++ b/lib/firebase/admin/auth/client.rb
@@ -87,6 +87,33 @@ module Firebase
           @user_manager.delete_user(uid)
         end
 
+        # Updates an existing user account with the specified properties.
+        #
+        # @param [String] uid The id of the user to be updated.
+        # @param [String, nil] display_name The user’s display name.
+        # @param [String, nil] email The user’s primary email.
+        # @param [Boolean, nil] email_verified A boolean indicating whether or not the user’s primary email is verified.
+        # @param [String, nil] phone_number The user’s primary phone number.
+        # @param [String, nil] photo_url The user’s photo URL.
+        # @param [String, nil] password The user’s raw, unhashed password.
+        # @param [Boolean, nil] disabled A boolean indicating whether or not the user account is disabled.
+        #
+        # @raise [UpdateUserError] if a user cannot be updated.
+        #
+        # @return [UserRecord]
+        def update_user(uid: nil, display_name: nil, email: nil, email_verified: nil, phone_number: nil, photo_url: nil, password: nil, disabled: nil)
+          @user_manager.update_user(
+            uid: uid,
+            display_name: display_name,
+            email: email,
+            email_verified: email_verified,
+            phone_number: phone_number,
+            photo_url: photo_url,
+            password: password,
+            disabled: disabled
+          )
+        end
+
         # Verifies the signature and data for the provided JWT.
         #
         # Accepts a signed token string, verifies that it is current, was issued to this project, and that

--- a/lib/firebase/admin/auth/error.rb
+++ b/lib/firebase/admin/auth/error.rb
@@ -18,6 +18,9 @@ module Firebase
 
       # Raised when a user cannot be created.
       class CreateUserError < Error; end
+
+      # Raised when a user cannot be updated.
+      class UpdateUserError < Error; end
     end
   end
 end

--- a/lib/firebase/admin/auth/user_manager.rb
+++ b/lib/firebase/admin/auth/user_manager.rb
@@ -42,7 +42,7 @@ module Firebase
             password: validate_password(password),
             emailVerified: to_boolean(email_verified),
             disabled: to_boolean(disabled),
-            custom_claims: validate_custom_claims(custom_claims)&.to_json,
+            customAttributes: validate_custom_claims(custom_claims)&.to_json,
           }.compact
           res = @client.post(with_path("accounts"), payload).body
           uid = res&.fetch("localId")

--- a/lib/firebase/admin/auth/user_manager.rb
+++ b/lib/firebase/admin/auth/user_manager.rb
@@ -48,6 +48,37 @@ module Firebase
           get_user_by(uid: uid)
         end
 
+        # Updates an existing user account with the specified properties.
+        #
+        # @param [String] uid The id of the user to update.
+        # @param [String, nil] display_name The user’s display name.
+        # @param [String, nil] email The user’s primary email.
+        # @param [Boolean, nil] email_verified A boolean indicating whether or not the user’s primary email is verified.
+        # @param [String, nil] phone_number The user’s primary phone number.
+        # @param [String, nil] photo_url The user’s photo URL.
+        # @param [String, nil] password The user’s raw, unhashed password.
+        # @param [Boolean, nil] disabled A boolean indicating whether or not the user account is disabled.
+        #
+        # @raise [UpdateUserError] if a user cannot be updated.
+        #
+        # @return [UserRecord]
+        def update_user(uid: nil, display_name: nil, email: nil, email_verified: nil, phone_number: nil, photo_url: nil, password: nil, disabled: nil)
+          payload = {
+            localId: validate_uid(uid),
+            displayName: validate_display_name(display_name),
+            email: validate_email(email),
+            phoneNumber: validate_phone_number(phone_number),
+            photoUrl: validate_photo_url(photo_url),
+            password: validate_password(password),
+            emailVerified: to_boolean(email_verified),
+            disabled: to_boolean(disabled)
+          }.compact
+          res = @client.post(with_path("accounts:update"), payload).body
+          uid = res&.fetch("localId")
+          raise UpdateUserError, "failed to update user #{res}" if uid.nil?
+          get_user_by(uid: uid)
+        end
+
         # Gets the user corresponding to the provided key
         #
         # @param [Hash] query Query parameters to search for a user by.

--- a/lib/firebase/admin/auth/user_manager.rb
+++ b/lib/firebase/admin/auth/user_manager.rb
@@ -27,11 +27,12 @@ module Firebase
         # @param [String, nil] photo_url The user’s photo URL.
         # @param [String, nil] password The user’s raw, unhashed password.
         # @param [Boolean, nil] disabled A boolean indicating whether or not the user account is disabled.
+        # @param [Hash, nil] custom_claims "Custom attributes" to store on the user, which will appear in their auth token.
         #
         # @raise [CreateUserError] if a user cannot be created.
         #
         # @return [UserRecord]
-        def create_user(uid: nil, display_name: nil, email: nil, email_verified: nil, phone_number: nil, photo_url: nil, password: nil, disabled: nil)
+        def create_user(uid: nil, display_name: nil, email: nil, email_verified: nil, phone_number: nil, photo_url: nil, password: nil, disabled: nil, custom_claims: nil)
           payload = {
             localId: validate_uid(uid),
             displayName: validate_display_name(display_name),
@@ -40,7 +41,8 @@ module Firebase
             photoUrl: validate_photo_url(photo_url),
             password: validate_password(password),
             emailVerified: to_boolean(email_verified),
-            disabled: to_boolean(disabled)
+            disabled: to_boolean(disabled),
+            custom_claims: validate_custom_claims(custom_claims)&.to_json,
           }.compact
           res = @client.post(with_path("accounts"), payload).body
           uid = res&.fetch("localId")
@@ -58,11 +60,12 @@ module Firebase
         # @param [String, nil] photo_url The user’s photo URL.
         # @param [String, nil] password The user’s raw, unhashed password.
         # @param [Boolean, nil] disabled A boolean indicating whether or not the user account is disabled.
+        # @param [Hash, nil] custom_claims "Custom attributes" to store on the user, which will appear in their auth token. Set to an empty hash to clear.
         #
         # @raise [UpdateUserError] if a user cannot be updated.
         #
         # @return [UserRecord]
-        def update_user(uid: nil, display_name: nil, email: nil, email_verified: nil, phone_number: nil, photo_url: nil, password: nil, disabled: nil)
+        def update_user(uid: nil, display_name: nil, email: nil, email_verified: nil, phone_number: nil, photo_url: nil, password: nil, disabled: nil, custom_claims: nil)
           payload = {
             localId: validate_uid(uid),
             displayName: validate_display_name(display_name),
@@ -71,7 +74,8 @@ module Firebase
             photoUrl: validate_photo_url(photo_url),
             password: validate_password(password),
             emailVerified: to_boolean(email_verified),
-            disabled: to_boolean(disabled)
+            disabled: to_boolean(disabled),
+            customAttributes: validate_custom_claims(custom_claims)&.to_json,
           }.compact
           res = @client.post(with_path("accounts:update"), payload).body
           uid = res&.fetch("localId")

--- a/lib/firebase/admin/auth/utils.rb
+++ b/lib/firebase/admin/auth/utils.rb
@@ -50,6 +50,12 @@ module Firebase
           name
         end
 
+        def validate_custom_claims(claims, required: false)
+          return nil if claims.nil? && !required
+          raise ArgumentError, "custom_claims must be a hash" unless claims.is_a?(Hash)
+          claims
+        end
+
         def to_boolean(val)
           !!val unless val.nil?
         end


### PR DESCRIPTION
- Remove ruby version in Gemfile so we can develop with other releases
- Remove version lock of activesupport (Rails) so we can use this gem with our older Rails version
- Add `update_user` action
- Add `customAttributes` to both `update_user` and `create_user`